### PR TITLE
use setuptools setup() and stop patching scheme

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,10 @@
-from distutils.core import setup
-from pip.req import parse_requirements
-from setuptools import find_packages
+from setuptools import setup, find_packages
 from distutils.command.install import INSTALL_SCHEMES
+from pip.req import parse_requirements
 
 import time
 _version = "1.0.dev%s" % int(time.time())
 _packages = find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"])
-
-for scheme in INSTALL_SCHEMES.values():
-    scheme['data'] = scheme['purelib']
 
 reqs_generator = parse_requirements("requirements.txt")
 reqs = [str(r.req) for r in reqs_generator]


### PR DESCRIPTION
@doismellburning I think it's save to switch to setuptools and remove the INSTALL_SCHEMES patching (as we don't install package_data with anton anyway)