### PR TITLE
add test for IRC ping

### DIFF
--- a/anton/irc_client.py
+++ b/anton/irc_client.py
@@ -92,18 +92,18 @@ class IRC(gevent.Greenlet):
         }
         return source
 
-    def process_line(self, type, obj):
-        if type == "PING":
+    def process_line(self, msgtype, obj):
+        if msgtype == "PING":
             self.write("PONG " + obj["args"][0])
-        elif type == "PRIVMSG":
+        elif msgtype == "PRIVMSG":
             source = self.to_source(obj["prefix"])
             if obj["args"][0][0] == "#":
                 events.fire("chanmsg", self, {"source": source, "channel": obj["args"][0], "message": obj["args"][1]})
             else:
                 events.fire("privmsg", self, {"source": source, "message": obj["args"][1]})
-        elif type == "JOIN":
+        elif msgtype == "JOIN":
             events.fire("join", self, {"source": self.to_source(obj["prefix"]), "channel": obj["args"][0]})
-        elif type == "001":
+        elif msgtype == "001":
             for channel in config.BOT_CHANNELS.split(','):
                 self.write("JOIN %s" % channel.strip())
         else:

--- a/anton/tests/test_irc.py
+++ b/anton/tests/test_irc.py
@@ -88,6 +88,7 @@ class TestIRCServer(gevent.server.StreamServer):
         while not self._message:
             gevent.sleep(0)
         sock.send(self._message)
+        _log.debug("Server sent %s", self._message)
         self._message = ""
 
     def queuemessage(self, msg):
@@ -183,3 +184,11 @@ class TestIRCProtocol(unittest.TestCase):
         gevent.wait(timeout=2)
         self.assertTrue(ircs.message_received)
         self.assertEqual(ircs.received[-1], "NOTICE TheFonz :thumbsup\r\n")
+
+    def test_ping(self):
+        ircs, ircc = TestIRCProtocol.setup_irctest("PONG ramalamadingdong", 1, 3)
+
+        ircs.queuemessage(": PING :ramalamadingdong\r\n")
+        gevent.wait(timeout=2)
+        self.assertTrue(ircs.message_received)
+        self.assertEqual(ircs.received[-1], "PONG ramalamadingdong\r\n")


### PR DESCRIPTION
this is forked from #41 as it depends on coverage

It also changes `process_line` to not override the built-in `type` by renaming the parameter to `msgtype`.

@doismellburning thx for reviewing ;)