### PR TITLE
Refactor IRC client into multiple Greenlets

### DIFF
--- a/anton/irc_client.py
+++ b/anton/irc_client.py
@@ -3,6 +3,8 @@ import socket
 import ssl
 import events
 import gevent
+import gevent.queue
+import gevent.event
 
 from anton import util
 from anton import config
@@ -11,7 +13,7 @@ from anton import config
 _log = logging.getLogger(__name__)
 
 
-class IRC(gevent.Greenlet):
+class IRC(object):
     def __init__(self, max_reconnects=0, max_messages=0):
         """
         :param max_reconnects: number of reconnection attempts (0 means unlimited [default])
@@ -24,8 +26,20 @@ class IRC(gevent.Greenlet):
         self.max_messages = max_messages
         self.current_reconnects = 0
         self.current_messagecount = 0
+        self._message_queue = gevent.queue.Queue()
+        self.reader_greenlet = None
+        self.writer_greenlet = None
+        self._disconnect_event = gevent.event.Event()
+        self._shutdown_event = gevent.event.Event()
+        self.started = False
+        self.stopped = False
 
     def connect(self, addr):
+        """
+        Connects the IRC client to a server and creates reader and writer threads which process messages and
+        send queued IRC messages back to the server.
+        """
+        self._disconnect_event.clear()
         self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         if config.IRC_USESSL in ["yes", "true", "1"]:
             self._socket = ssl.wrap_socket(self._socket)
@@ -36,16 +50,69 @@ class IRC(gevent.Greenlet):
 
         self._socket.send("USER %s %s %s :%s\r\n" % (config.BOT_USERNAME, "wibble", "wibble", config.BOT_REALNAME))
         self._socket.send("NICK %s\r\n" % config.BOT_NICKNAME)
+
+        self.reader_greenlet = gevent.spawn(self._reader)
+        self.writer_greenlet = gevent.spawn(self._writer)
         return True
+
+    def _reader(self):
+        buf = ""
+        while self.allow_message_processing():
+            self.current_messagecount = self.current_messagecount + 1
+
+            line = None
+            try:
+                line = self._socket.recv(8192)
+            except socket.error:
+                # we swallow the socket.error raised by gevent.socket.cancel_wait_ex here because it's perfectly
+                # normal for another Greenlet to close our underlying socket while we were blocked in recv().
+                break
+
+            if not line:
+                break
+
+            buf += line
+            lines = buf.split("\n")
+            buf = lines.pop(-1)
+
+            for line in lines:
+                try:
+                    j = self.parse_line(line)
+                except ValueError, e:
+                    _log.error("line: " + repr(line), e)
+                    continue
+                _log.debug(j)
+
+                gevent.spawn(self.process_line, j["type"], j.get("data"))
+
+        _log.debug("Message count: %s/%s", self.current_messagecount, self.max_messages)
+        self.current_messagecount = 0
+
+    def _writer(self):
+        while self._message_queue.peek():
+            msg = self._message_queue.get()
+
+            if msg is StopIteration:
+                return
+
+            self.split_send(lambda m: self.write("%s %s :%s" % (msg['type'], msg['target'], m)), msg['message'])
 
     def write(self, message):
         self._socket.send("%s\r\n" % message.encode("utf8"))
 
     def chanmsg(self, channel, message):
-        self.split_send(lambda message: self.write("PRIVMSG %s :%s" % (channel, message)), message)
+        self._message_queue.put({
+            'type': 'PRIVMSG',
+            'target': channel,
+            'message': message,
+        })
 
     def privnotice(self, target, message):
-        self.split_send(lambda message: self.write("NOTICE %s :%s" % (target, message)), message)
+        self._message_queue.put({
+            'type': 'NOTICE',
+            'target': target,
+            'message': message,
+        })
 
     def wallusers(self, message):
         # self.split_send(lambda message: self.write("wallusers", {"message": message}), message)
@@ -110,56 +177,77 @@ class IRC(gevent.Greenlet):
             _log.warning("bad command type: %r: %r" % (type, obj))
 
     def allow_reconnect(self):
-        if self.max_reconnects == 0:
+        if self.max_reconnects == 0 and not self._shutdown_event.is_set():
+            return True
+        elif self.current_reconnects < self.max_reconnects and not self._shutdown_event.is_set():
             return True
         else:
-            return self.current_reconnects < self.max_reconnects
+            self._shutdown_event.set()
+            return False
 
     def allow_message_processing(self):
-        if self.max_messages == 0:
+        if self.max_messages == 0 and not self._disconnect_event.is_set():
+            return True
+        elif self.current_messagecount < self.max_messages and not self._disconnect_event.is_set():
             return True
         else:
-            return self.current_messagecount < self.max_messages
+            self._disconnect_event.set()
+            return False
 
-    def _run(self):
-        while self.allow_reconnect():
-            self.current_reconnects = self.current_reconnects + 1
-            _log.info("connecting to %s:%s..." % config.BACKEND)
-            self.connect(config.BACKEND)
-            _log.info("connected!")
+    def start(self):
+        """
+        Starts the client with a watcher thread which will reconnect the client after a 5 second wait
+        when it gets disconnected (up to self.max_reconnects) or receives the maximum messages allowed
+        before it must reconnect (self.max_messages).
 
-            self.wallops("anton online")
-            buf = ""
-            while self.allow_message_processing():
-                self.current_messagecount = self.current_messagecount + 1
-                line = self._socket.recv(8192)
-                if not line:
-                    break
+        :return: The watcher Greenlet that you can gevent.wait() on, for example.
+        """
+        if self.started:
+            return
 
-                buf += line
-                lines = buf.split("\n")
-                buf = lines.pop(-1)
+        self.started = True
 
-                for line in lines:
-                    try:
-                        j = self.parse_line(line)
-                    except ValueError, e:
-                        _log.error("line: " + repr(line), e)
-                        continue
-                    _log.debug(j)
+        def _watcher():
+            while self.allow_reconnect():
+                self.current_reconnects = self.current_reconnects + 1
+                _log.info("connecting to %s:%s..." % config.BACKEND)
+                self.connect(config.BACKEND)
+                _log.info("connected!")
 
-                    gevent.spawn(self.process_line, j["type"], j.get("data"))
+                self.wallops("anton online")
 
-            _log.debug("Message count: %s", self.current_messagecount)
-            if not self.allow_message_processing():
-                _log.debug("Maximum number of messages per connection reached (%s)", self.max_messages)
+                self._disconnect_event.wait()
 
-            self.current_messagecount = 0
-            self._socket.close()
-            self._socket = None
+                if self.allow_reconnect():
+                    _log.info("disconnected, retrying in 5s...")
+                    gevent.sleep(5)
 
-            if self.allow_reconnect():
-                _log.info("disconnected, retrying in 5s...")
-                gevent.sleep(5)
+            if self.current_reconnects >= self.max_reconnects:
+                _log.warning("Maximum reconnection attempts reached (%s)", self.max_reconnects)
 
-        _log.warning("Maximum reconnection attempts reached (%s)", self.max_reconnects)
+            if self._shutdown_event.is_set():
+                _log.info("Shutting down...")
+
+        return gevent.spawn(_watcher)
+
+    def stop(self):
+        """
+        Disconnects the client from the server immediately and shuts it down (it won't reconnect after being stopped).
+        """
+        if self.stopped:
+            return
+
+        self.stopped = True
+        self._shutdown_event.set()
+        self._disconnect_event.set()
+        self._socket.close()
+        self._message_queue.put(StopIteration)
+
+    def run_eventloop(self, timeout=None):
+        """
+        You can call this method to block and run the IRC client until it disconnects. It's a helper method
+        like gevent.baseserver.BaseServer.serve_forever, i.e. it will block until the client dies.
+        """
+        if not self.started:
+            self.start()
+        self._shutdown_event.wait(timeout=timeout)

--- a/anton/irc_client.py
+++ b/anton/irc_client.py
@@ -210,7 +210,7 @@ class IRC(object):
         def _watcher():
             while self.allow_reconnect():
                 self.current_reconnects = self.current_reconnects + 1
-                _log.info("connecting to %s:%s..." % config.BACKEND)
+                _log.info("connecting to %s:%s...", config.BACKEND)
                 self.connect(config.BACKEND)
                 _log.info("connected!")
 

--- a/anton/irc_client.py
+++ b/anton/irc_client.py
@@ -210,7 +210,7 @@ class IRC(object):
         def _watcher():
             while self.allow_reconnect():
                 self.current_reconnects = self.current_reconnects + 1
-                _log.info("connecting to %s:%s...", config.BACKEND)
+                _log.info("connecting to %s:%s...", config.BACKEND[0], config.BACKEND[1])
                 self.connect(config.BACKEND)
                 _log.info("connected!")
 

--- a/anton/tests/test_irc.py
+++ b/anton/tests/test_irc.py
@@ -205,5 +205,15 @@ class TestIRCClient(unittest.TestCase):
             ircs.close()
 
         gevent.spawn(killafter1second)
-        gevent.wait(timeout=2)
-        self.assertTrue(ircc.stopped)
+        gevent.sleep(1)
+        try:
+            ircc.reader_greenlet.get(timeout=2)
+        except gevent.Timeout:
+            self.fail("The reader greenlet hasn't closed shop after the stop event")
+
+        try:
+            ircc.writer_greenlet.get(timeout=2)
+        except gevent.Timeout:
+            self.fail("The writer greenlet hasn't closed shop after the stop event")
+
+        gevent.wait(timeout=2) # if anything else blocks, we find it here

--- a/anton/tests/test_irc.py
+++ b/anton/tests/test_irc.py
@@ -216,4 +216,4 @@ class TestIRCClient(unittest.TestCase):
         except gevent.Timeout:
             self.fail("The writer greenlet hasn't closed shop after the stop event")
 
-        gevent.wait(timeout=2) # if anything else blocks, we find it here
+        gevent.wait(timeout=2)  # if anything else blocks, we find it here


### PR DESCRIPTION
The way we did it before ... worked, unless the HTTP module which is entirely cooperatively multithreaded tried to send messages too fast. That could result in https://sentry.sys.laterpay.net/laterpay/sys/group/2600/ (`AssertionError: gevent.socket in _wait - This socket is already used by another greenlet`).

This PR refactors the IRC module in three cooperative threads:
  1. a watcher greenlet that handles socket disconnects from the IRC server
  2. a reader greenlet that reads incoming messages and dispatches them to anton modules
  3. a writer greenlet that writes messages from a fifo queue to the IRC server

`chanmsg` and `privmsg` now only queue messages to be sent to the IRC server.

In the future this will also allow us to throttle message throughput so as not to trip flood protections. 

Also, instead of running `while True` this PR makes the watcher thread check `Event` instances, which will also make it easy to handle system signals correctly in the future. And finally, the new architecture allows `anton.irc_client.Client` to run standalone (through `run_eventloop`) if you ever wanted to run it without on relying the `WSGIServer.serve_forever` event loop we've been relying on previously.