### PR TITLE
allow IRC names without ident or host

### DIFF
--- a/anton/irc_client.py
+++ b/anton/irc_client.py
@@ -152,10 +152,17 @@ class IRC(object):
 
     @staticmethod
     def to_source(prefix):
+        ident = ""
+        hostname = ""
+        if "@" in prefix and "!" in prefix:
+            ident = prefix.split("@")[0].split("!")[1]
+        if "@" in prefix:
+            hostname = prefix.split("@")[1]
+
         source = {
             "nick": prefix.split("!")[0],
-            "ident": prefix.split("@")[0].split("!")[1],
-            "hostname": prefix.split("@")[1]
+            "ident": ident,
+            "hostname": hostname
         }
         return source
 

--- a/anton/tests/test_irc.py
+++ b/anton/tests/test_irc.py
@@ -130,6 +130,21 @@ class TestIRCProtocol(unittest.TestCase):
             }
         })
 
+    def test_to_source(self):
+        ircc = irc_client.IRC()
+        source = ircc.to_source("nick!ident@host")
+        self.assertDictEqual(source, {
+            "nick": "nick",
+            "ident": "ident",
+            "hostname": "host",
+        })
+        source = ircc.to_source("slackbot")
+        self.assertDictEqual(source, {
+            "nick": "slackbot",
+            "ident": "",
+            "hostname": "",
+        })
+
 
 class TestIRCClient(unittest.TestCase):
     """


### PR DESCRIPTION
Slack sends messages from "slackbot" without ident or hostname parts. This resulted in

```
Traceback (most recent call last):
  File "/opt/lp-apps/anton/lib/python2.7/site-packages/gevent/greenlet.py", line 327, in run
    result = self._run(*self.args, **self.kwargs)
  File "/opt/lp-apps/anton/lib/python2.7/site-packages/anton/irc_client.py", line 166, in process_line
    source = self.to_source(obj["prefix"])
  File "/opt/lp-apps/anton/lib/python2.7/site-packages/anton/irc_client.py", line 157, in to_source
    "ident": prefix.split("@")[0].split("!")[1],
IndexError: list index out of range
```

So we need to parse that correctly.