### PR TITLE
add urllib3 SSL verification support and SNI to anton

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,9 @@ gevent==1.0.1
 github3.py==0.9.3
 greenlet==0.4.5
 requests==2.6.0
+pyopenssl==0.15.1
+ndg-httpsclient==0.4.0
+pyasn1==0.1.7
 requests-oauthlib==0.4.2
 wsgiref==0.1.2
 cssselect==0.9.1


### PR DESCRIPTION
We are seeing a lot of these:

```
/opt/lp-apps/anton/lib/python2.7/site-packages/requests/packages/urllib3/util/ssl_.py:79: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail. For more information, see https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning.
```

and we want to be secure :)