### PR TITLE
detect IRC disconnects

### DIFF
--- a/anton/config.py
+++ b/anton/config.py
@@ -9,6 +9,18 @@ IRC_MAX_CONNECTATTEMPTS = os.getenv("IRC_MAX_CONNECTATTEMPTS", "0")
 IRC_MAX_MESSAGESPERCONNECTION = os.getenv("IRC_MAX_MESSAGESPERCONNECTION", "0")
 IRC_USESSL = os.getenv("IRC_USESSL", "0")
 
+try:
+    IRC_PING_RECONNECT_TIMEOUT = int(os.getenv("IRC_PING_RECONNECT_TIMEOUT", "60"))
+except ValueError:
+    print("IRC_PING_RECONNECT_TIMEOUT must be a integer (count of seconds)")
+    sys.exit(1)
+
+try:
+    IRC_CONNECTIONCHECK_TIMEOUT = int(os.getenv("IRC_PING_RECONNECT_TIMEOUT", "60"))
+except ValueError:
+    print("IRC_PING_RECONNECT_TIMEOUT must be a integer (count of seconds)")
+    sys.exit(1)
+
 BACKEND = IRC_SERVER, int(IRC_PORT)
 HTTP_ROOT = "/bot"
 HTTP_BINDADDRESS = os.getenv("HTTP_BINDADDRESS", "127.0.0.1")

--- a/anton/irc_client.py
+++ b/anton/irc_client.py
@@ -1,6 +1,9 @@
+from _ssl import SSLError
 import logging
+import os
 import socket
 import ssl
+import time
 import events
 import gevent
 import gevent.queue
@@ -33,6 +36,7 @@ class IRC(object):
         self._shutdown_event = gevent.event.Event()
         self.started = False
         self.stopped = False
+        self.last_ping = 0
 
     def connect(self, addr):
         """
@@ -53,6 +57,8 @@ class IRC(object):
 
         self.reader_greenlet = gevent.spawn(self._reader)
         self.writer_greenlet = gevent.spawn(self._writer)
+
+        self.last_ping = time.time()  # we have just connected, so let's pretend we just got pinged
         return True
 
     def _reader(self):
@@ -62,13 +68,18 @@ class IRC(object):
 
             line = None
             try:
+                _log.debug("listening %s", self.reader_greenlet)
                 line = self._socket.recv(8192)
-            except socket.error:
+            except socket.error as e:
                 # we swallow the socket.error raised by gevent.socket.cancel_wait_ex here because it's perfectly
                 # normal for another Greenlet to close our underlying socket while we were blocked in recv().
+                _log.debug("socket.error %s %s %s", os.strerror(e.errno), e, self.reader_greenlet)
+                self.disconnect()
                 break
 
             if not line:
+                _log.debug("empty response received from IRC socket '%s' %s", line, self.reader_greenlet)
+                self.disconnect()
                 break
 
             buf += line
@@ -85,7 +96,7 @@ class IRC(object):
 
                 gevent.spawn(self.process_line, j["type"], j.get("data"))
 
-        _log.debug("Message count: %s/%s", self.current_messagecount, self.max_messages)
+        _log.debug("Message count: %s/%s %s", self.current_messagecount, self.max_messages, self.reader_greenlet)
         self.current_messagecount = 0
 
     def _writer(self):
@@ -98,7 +109,14 @@ class IRC(object):
             self.split_send(lambda m: self.write("%s %s :%s" % (msg['type'], msg['target'], m)), msg['message'])
 
     def write(self, message):
-        self._socket.send("%s\r\n" % message.encode("utf8"))
+        try:
+            self._socket.send("%s\r\n" % message.encode("utf8"))
+        except SSLError as e:
+            _log.debug("Sending to server raised %s", e)
+            self.disconnect()
+        except socket.error as e:
+            _log.debug("Sending to server raised %s", e)
+            self.disconnect()
 
     def chanmsg(self, channel, message):
         self._message_queue.put({
@@ -130,7 +148,6 @@ class IRC(object):
 
         for x in util.split_lines(split_data):
             fn(util.decode_irc(x, redecode=False))
-        return
 
     @staticmethod
     def parse_line(s):
@@ -161,6 +178,7 @@ class IRC(object):
 
     def process_line(self, msgtype, obj):
         if msgtype == "PING":
+            self.last_ping = time.time()
             self.write("PONG " + obj["args"][0])
         elif msgtype == "PRIVMSG":
             source = self.to_source(obj["prefix"])
@@ -216,7 +234,14 @@ class IRC(object):
 
                 self.wallops("anton online")
 
-                self._disconnect_event.wait()
+                _log.debug("Entering inner loop with timeout %s", config.IRC_CONNECTIONCHECK_TIMEOUT)
+                while not self._disconnect_event.wait(timeout=config.IRC_CONNECTIONCHECK_TIMEOUT):
+                    t = time.time() - self.last_ping
+                    if t > config.IRC_PING_RECONNECT_TIMEOUT:
+                        # we haven't had a PING in a while... we should assume the connection is broken
+                        _log.warning("PING timeout (%s > %s), reconnecting...", t, config.IRC_PING_RECONNECT_TIMEOUT)
+                        self.disconnect()
+                        break
 
                 if self.allow_reconnect():
                     _log.info("disconnected, retrying in 5s...")
@@ -239,9 +264,19 @@ class IRC(object):
 
         self.stopped = True
         self._shutdown_event.set()
+        self.disconnect()
+
+    def disconnect(self):
         self._disconnect_event.set()
-        self._socket.close()
         self._message_queue.put(StopIteration)
+        try:
+            self._socket.shutdown(socket.SHUT_RDWR)
+            self._socket.close()
+        except socket.error as e:
+            # at this point the socket might already have been closed or gone stale, so this will sometimes
+            # throw errors which are meaningless to us. Shutting down the socket here is about being a good citizen
+            # and sending TCP FIN if we still can.
+            _log.debug("Disconnecting from server raised %s", e)
 
     def run_eventloop(self, timeout=None):
         """

--- a/anton/tests/test_irc.py
+++ b/anton/tests/test_irc.py
@@ -1,9 +1,11 @@
 # -* coding: utf-8 *-
+from _ssl import SSLError
 import logging
 
 import re
 import unittest
 import socket
+import mock
 import anton.config
 import gevent.monkey
 import gevent.server
@@ -68,6 +70,7 @@ class TestIRCServer(gevent.server.StreamServer):
         self._irc_message_queue = gevent.queue.Queue()
         self.checkfor = checkfor
         self.message_received = False
+        self.sockets = []
         super(TestIRCServer, self).__init__(*args, **kwargs)
 
     def handle(self, sock, address):
@@ -75,11 +78,14 @@ class TestIRCServer(gevent.server.StreamServer):
         gevent.spawn(self.write, sock)
 
     def read(self, sock):
+        if sock not in self.sockets:
+            self.sockets.append(sock)
+
         filelike = sock.makefile()
         while True:
             line = filelike.readline()
             if line:
-                _log.debug("Server received %s", line)
+                _log.debug("Server %s received %s", self, line)
                 self.received.append(line)
                 if self.checkfor in line:
                     self.message_received = True
@@ -89,6 +95,9 @@ class TestIRCServer(gevent.server.StreamServer):
                 break
 
     def write(self, sock):
+        if sock not in self.sockets:
+            self.sockets.append(sock)
+
         while self._irc_message_queue.peek():
             msg = self._irc_message_queue.get()
 
@@ -218,6 +227,17 @@ class TestIRCClient(unittest.TestCase):
         self.assertTrue(ircs.message_received)
         self.assertEqual(ircs.received[-1], "PONG ramalamadingdong\r\n")
 
+    def test_ping_timeout(self):
+        anton.config.IRC_PING_RECONNECT_TIMEOUT = 1
+        anton.config.IRC_CONNECTIONCHECK_TIMEOUT = 1
+        ircs, ircc = self.setup_irctest("PONG ramalamadingdong", 1, 0)
+
+        ircs.queuemessage(": PING :ramalamadingdong\r\n")
+        gevent.wait(timeout=5)
+        self.assertTrue(ircs.message_received)
+        self.assertEqual(ircs.received[-1], "PONG ramalamadingdong\r\n")
+        self.assertTrue(ircc._disconnect_event.is_set())
+
     def test_events(self):
         ircs, ircc = self.setup_irctest("thumbsup", 1, 3)
 
@@ -239,3 +259,46 @@ class TestIRCClient(unittest.TestCase):
             self.fail("The writer greenlet hasn't closed shop after the stop event")
 
         gevent.wait(timeout=2)  # if anything else blocks, we find it here
+
+    def test_server_socket_disconnect(self):
+        ircs, ircc = self.setup_irctest("unmatched", 1, 3)
+
+        def close_server_socket_after_1second():
+            gevent.sleep(1)
+            _log.debug("closing server socket")
+            for s in ircs.sockets:
+                s.shutdown(socket.SHUT_RDWR)
+                s.close()
+
+        inner = gevent.spawn(close_server_socket_after_1second)
+        inner.join()
+        ircc._disconnect_event.wait(timeout=1)
+        self.assertTrue(ircc._disconnect_event.is_set())
+
+    def test_client_socket_disconnect(self):
+        ircs, ircc = self.setup_irctest("unmatched", 1, 3)
+
+        def close_client_socket_after_1second():
+            gevent.sleep(1)
+            _log.debug("closing client socket")
+            # this will make gevent.socket.cancel_wait raise socket.error
+            ircc._socket.close()
+
+        inner = gevent.spawn(close_client_socket_after_1second)
+        inner.join()
+        ircc._disconnect_event.wait(timeout=1)
+        self.assertTrue(ircc._disconnect_event.is_set())
+
+    def test_disconnect_on_sslerror(self):
+        ircc = irc_client.IRC()
+        ircc._socket = mock.Mock()
+        ircc._socket.send.side_effect = SSLError("mock ssl error")
+        ircc.write(u"test")
+        self.assertTrue(ircc._disconnect_event.is_set())
+
+    def test_disconnect_on_socketerror(self):
+        ircc = irc_client.IRC()
+        ircc._socket = mock.Mock()
+        ircc._socket.send.side_effect = socket.error("mock socket error")
+        ircc.write(u"test")
+        self.assertTrue(ircc._disconnect_event.is_set())


### PR DESCRIPTION
This depends on #47 

So the Slack IRC bridge falls over from time to time and then anton just continues to blindly send TCP packets to Slack without realizing that its sockets have been closed.

This PR remedies that by:
  * detecting closed sockets
  * detecting SSL connection problems
  * checking for PING messages from the server (one per minute is the default)

when one of the above conditions happen, the IRC client disconnects responsibly and tries to reconnect.