### PR TITLE
it's better to wait for the Greenlet to complete than just sleep for a second

### DIFF
--- a/anton/tests/test_irc.py
+++ b/anton/tests/test_irc.py
@@ -212,8 +212,8 @@ class TestIRCClient(unittest.TestCase):
             ircc.stop()
             ircs.close()
 
-        gevent.spawn(killafter1second)
-        gevent.sleep(1)
+        inner = gevent.spawn(killafter1second)
+        inner.join(timeout=3)
         try:
             ircc.reader_greenlet.get(timeout=2)
         except gevent.Timeout:


### PR DESCRIPTION
This is just a small change bringing `test_events` in line with the other tests after #47 and #48. It's just better practice.